### PR TITLE
Remove explicit new-line from log message

### DIFF
--- a/kie-api/src/main/java/org/kie/api/internal/utils/ServiceDiscoveryImpl.java
+++ b/kie-api/src/main/java/org/kie/api/internal/utils/ServiceDiscoveryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015, 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ public class ServiceDiscoveryImpl {
         } else {
             services.put( key, newInstance( classLoader, value ) );
         }
-        log.info( "Adding Service {}\n", value );
+        log.info( "Adding Service {}", value );
     }
 
     private <T> T newInstance( ClassLoader classLoader, String className ) {


### PR DESCRIPTION
Newlines are handled by the logging framework. Adding an explicit newline will cause a double new-line in the logs:

~~~
2018-05-07 10:01:47,483 | INFO  | FelixStartLevel  | KarArtifactInstaller             | 46 - org.apache.karaf.deployer.kar - 2.4.0 | Timestamps for Karaf archives will be extracted to /home/jreimann/Development/workspace-drools/droolsjbpm-integration/kie-osgi/kie-karaf-itests/target/paxexam/unpack/2ffbdb13-4952-40d7-b6c8-8cfa6d14ecf1/system/.timestamps
2018-05-07 10:01:47,572 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Loading kie.conf from  
2018-05-07 10:01:47,572 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Discovered kie.conf url=bundle://71.0:1/META-INF/kie.conf 
2018-05-07 10:01:47,577 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.kie.internal.services.KieWeaversImpl

2018-05-07 10:01:47,579 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.kie.internal.services.KieBeliefsImpl

2018-05-07 10:01:47,579 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.kie.internal.services.KieAssemblersImpl

2018-05-07 10:01:47,580 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.kie.internal.services.KieRuntimesImpl

2018-05-07 10:01:47,581 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Loading kie.conf from  
2018-05-07 10:01:47,584 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Discovered kie.conf url=bundle://72.0:1/META-INF/kie.conf 
2018-05-07 10:01:47,585 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.drools.core.io.impl.ResourceFactoryServiceImpl

2018-05-07 10:01:47,586 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.drools.core.marshalling.impl.MarshallerProviderImpl

2018-05-07 10:01:47,587 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.drools.core.concurrent.ExecutorProviderImpl

2018-05-07 10:01:47,590 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Loading kie.conf from  
2018-05-07 10:01:47,591 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Discovered kie.conf url=bundle://73.0:1/META-INF/kie.conf 
2018-05-07 10:01:47,595 | INFO  | FelixStartLevel  | ServiceDiscoveryImpl             | 70 - org.kie.api - 7.8.0.201804272239 | Adding Service org.drools.compiler.kie.builder.impl.KieServicesImpl

~~~